### PR TITLE
[REVIEW] v0.11 vs pySpark Notebook

### DIFF
--- a/vs_pyspark_netflow.ipynb
+++ b/vs_pyspark_netflow.ipynb
@@ -50,7 +50,7 @@
    ],
    "source": [
     "from blazingsql import BlazingContext\n",
-    "\n",
+    "# start up BlazingSQL\n",
     "bc = BlazingContext()"
    ]
   },
@@ -78,16 +78,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2020-01-20 21:56:58--  https://blazingsql-colab.s3.amazonaws.com/netflow_data/nf-chunk2.csv\n",
-      "Resolving blazingsql-colab.s3.amazonaws.com (blazingsql-colab.s3.amazonaws.com)... 52.217.4.52\n",
-      "Connecting to blazingsql-colab.s3.amazonaws.com (blazingsql-colab.s3.amazonaws.com)|52.217.4.52|:443... connected.\n",
+      "--2020-01-20 22:14:17--  https://blazingsql-colab.s3.amazonaws.com/netflow_data/nf-chunk2.csv\n",
+      "Resolving blazingsql-colab.s3.amazonaws.com (blazingsql-colab.s3.amazonaws.com)... 52.216.112.139\n",
+      "Connecting to blazingsql-colab.s3.amazonaws.com (blazingsql-colab.s3.amazonaws.com)|52.216.112.139|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 2725056295 (2.5G) [text/csv]\n",
       "Saving to: ‘data/nf-chunk2.csv’\n",
       "\n",
-      "nf-chunk2.csv       100%[===================>]   2.54G  46.2MB/s    in 48s     \n",
+      "nf-chunk2.csv       100%[===================>]   2.54G  51.8MB/s    in 49s     \n",
       "\n",
-      "2020-01-20 21:57:47 (53.6 MB/s) - ‘data/nf-chunk2.csv’ saved [2725056295/2725056295]\n",
+      "2020-01-20 22:15:06 (53.2 MB/s) - ‘data/nf-chunk2.csv’ saved [2725056295/2725056295]\n",
       "\n"
      ]
     }
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -126,10 +126,10 @@
     {
      "data": {
       "text/plain": [
-       "'/home/jupyter-winston/bsql-demos/data/nf-chunk2.csv'"
+       "'/home/winston/bsql-demos/data/nf-chunk2.csv'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -161,17 +161,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.4 ms, sys: 3.8 ms, total: 11.2 ms\n",
-      "Wall time: 10.9 ms\n"
+      "CPU times: user 9.9 ms, sys: 13.1 ms, total: 23 ms\n",
+      "Wall time: 1.14 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<pyblazing.apiv2.context.BlazingTable at 0x7f1ba8229198>"
+       "<pyblazing.apiv2.context.BlazingTable at 0x7f3e181d1bd0>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -199,8 +199,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4.3 s, sys: 2.51 s, total: 6.81 s\n",
-      "Wall time: 6.6 s\n"
+      "CPU times: user 5.07 s, sys: 2.61 s, total: 7.67 s\n",
+      "Wall time: 10.4 s\n"
      ]
     }
    ],
@@ -231,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -274,18 +274,6 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>172.10.1.162</td>\n",
-       "      <td>10.0.0.11</td>\n",
-       "      <td>87</td>\n",
-       "      <td>39628</td>\n",
-       "      <td>53983</td>\n",
-       "      <td>24</td>\n",
-       "      <td>2013-04-03 06:50:13</td>\n",
-       "      <td>2013-04-03 14:58:35</td>\n",
-       "      <td>87</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
        "      <td>172.30.2.60</td>\n",
        "      <td>10.0.0.9</td>\n",
        "      <td>82</td>\n",
@@ -297,31 +285,19 @@
        "      <td>82</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>172.10.1.162</td>\n",
+       "      <td>10.0.0.11</td>\n",
+       "      <td>87</td>\n",
+       "      <td>39628</td>\n",
+       "      <td>53983</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2013-04-03 06:50:13</td>\n",
+       "      <td>2013-04-03 14:58:35</td>\n",
+       "      <td>87</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>172.30.1.56</td>\n",
-       "      <td>172.0.0.1</td>\n",
-       "      <td>25</td>\n",
-       "      <td>3330</td>\n",
-       "      <td>3240</td>\n",
-       "      <td>67</td>\n",
-       "      <td>2013-04-03 01:59:09</td>\n",
-       "      <td>2013-04-03 22:05:39</td>\n",
-       "      <td>25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>172.30.1.85</td>\n",
-       "      <td>10.0.0.8</td>\n",
-       "      <td>84</td>\n",
-       "      <td>37828</td>\n",
-       "      <td>52864</td>\n",
-       "      <td>3</td>\n",
-       "      <td>2013-04-03 06:48:21</td>\n",
-       "      <td>2013-04-03 12:06:53</td>\n",
-       "      <td>84</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
        "      <td>10.1.0.76</td>\n",
        "      <td>172.10.1.82</td>\n",
        "      <td>1</td>\n",
@@ -333,16 +309,40 @@
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>172.30.1.56</td>\n",
+       "      <td>172.0.0.1</td>\n",
+       "      <td>25</td>\n",
+       "      <td>3330</td>\n",
+       "      <td>3240</td>\n",
+       "      <td>67</td>\n",
+       "      <td>2013-04-03 01:59:09</td>\n",
+       "      <td>2013-04-03 22:05:39</td>\n",
+       "      <td>25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>172.30.1.10</td>\n",
+       "      <td>10.0.0.12</td>\n",
+       "      <td>69</td>\n",
+       "      <td>31042</td>\n",
+       "      <td>43044</td>\n",
+       "      <td>25</td>\n",
+       "      <td>2013-04-03 06:48:01</td>\n",
+       "      <td>2013-04-03 12:11:40</td>\n",
+       "      <td>69</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>172.30.2.125</td>\n",
-       "      <td>10.0.0.9</td>\n",
-       "      <td>69</td>\n",
-       "      <td>30701</td>\n",
-       "      <td>41558</td>\n",
-       "      <td>341</td>\n",
-       "      <td>2013-04-03 06:50:50</td>\n",
-       "      <td>2013-04-03 12:12:37</td>\n",
-       "      <td>69</td>\n",
+       "      <td>172.10.1.89</td>\n",
+       "      <td>10.0.0.5</td>\n",
+       "      <td>112</td>\n",
+       "      <td>51222</td>\n",
+       "      <td>70260</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2013-04-03 06:48:24</td>\n",
+       "      <td>2013-04-03 15:17:39</td>\n",
+       "      <td>112</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -358,39 +358,39 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>172.10.1.106</td>\n",
-       "      <td>10.199.250.2</td>\n",
-       "      <td>40</td>\n",
-       "      <td>66638</td>\n",
-       "      <td>2863884</td>\n",
-       "      <td>24</td>\n",
-       "      <td>2013-04-03 07:19:02</td>\n",
-       "      <td>2013-04-03 10:12:35</td>\n",
-       "      <td>40</td>\n",
+       "      <td>172.30.2.125</td>\n",
+       "      <td>10.0.0.9</td>\n",
+       "      <td>69</td>\n",
+       "      <td>30701</td>\n",
+       "      <td>41558</td>\n",
+       "      <td>341</td>\n",
+       "      <td>2013-04-03 06:50:50</td>\n",
+       "      <td>2013-04-03 12:12:37</td>\n",
+       "      <td>69</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>172.30.1.201</td>\n",
-       "      <td>172.0.0.1</td>\n",
-       "      <td>29</td>\n",
-       "      <td>2610</td>\n",
-       "      <td>2610</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2013-04-03 00:26:46</td>\n",
-       "      <td>2013-04-03 23:06:00</td>\n",
-       "      <td>29</td>\n",
+       "      <td>172.30.1.85</td>\n",
+       "      <td>10.0.0.8</td>\n",
+       "      <td>84</td>\n",
+       "      <td>37828</td>\n",
+       "      <td>52864</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2013-04-03 06:48:21</td>\n",
+       "      <td>2013-04-03 12:06:53</td>\n",
+       "      <td>84</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>172.10.1.89</td>\n",
-       "      <td>10.0.0.5</td>\n",
-       "      <td>112</td>\n",
-       "      <td>51222</td>\n",
-       "      <td>70260</td>\n",
-       "      <td>24</td>\n",
-       "      <td>2013-04-03 06:48:24</td>\n",
-       "      <td>2013-04-03 15:17:39</td>\n",
-       "      <td>112</td>\n",
+       "      <td>10.0.0.9</td>\n",
+       "      <td>172.30.1.124</td>\n",
+       "      <td>1</td>\n",
+       "      <td>632</td>\n",
+       "      <td>391</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2013-04-03 10:36:04</td>\n",
+       "      <td>2013-04-03 10:36:04</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -398,31 +398,31 @@
       ],
       "text/plain": [
        "         source   destination  targetPorts  bytesOut  bytesIn  \\\n",
-       "0  172.10.1.162     10.0.0.11           87     39628    53983   \n",
-       "1   172.30.2.60      10.0.0.9           82     34839    47716   \n",
-       "2   172.30.1.56     172.0.0.1           25      3330     3240   \n",
-       "3   172.30.1.85      10.0.0.8           84     37828    52864   \n",
-       "4     10.1.0.76   172.10.1.82            1       633      392   \n",
-       "5  172.30.2.125      10.0.0.9           69     30701    41558   \n",
+       "0   172.30.2.60      10.0.0.9           82     34839    47716   \n",
+       "1  172.10.1.162     10.0.0.11           87     39628    53983   \n",
+       "2     10.1.0.76   172.10.1.82            1       633      392   \n",
+       "3   172.30.1.56     172.0.0.1           25      3330     3240   \n",
+       "4   172.30.1.10     10.0.0.12           69     31042    43044   \n",
+       "5   172.10.1.89      10.0.0.5          112     51222    70260   \n",
        "6  172.10.1.234      10.0.0.5          104     47287    64750   \n",
-       "7  172.10.1.106  10.199.250.2           40     66638  2863884   \n",
-       "8  172.30.1.201     172.0.0.1           29      2610     2610   \n",
-       "9   172.10.1.89      10.0.0.5          112     51222    70260   \n",
+       "7  172.30.2.125      10.0.0.9           69     30701    41558   \n",
+       "8   172.30.1.85      10.0.0.8           84     37828    52864   \n",
+       "9      10.0.0.9  172.30.1.124            1       632      391   \n",
        "\n",
        "   durationSeconds        firstFlowDate         lastFlowDate  attemptCount  \n",
-       "0               24  2013-04-03 06:50:13  2013-04-03 14:58:35            87  \n",
-       "1              134  2013-04-03 06:48:47  2013-04-03 12:12:37            82  \n",
-       "2               67  2013-04-03 01:59:09  2013-04-03 22:05:39            25  \n",
-       "3                3  2013-04-03 06:48:21  2013-04-03 12:06:53            84  \n",
-       "4                0  2013-04-03 09:55:05  2013-04-03 09:55:05             1  \n",
-       "5              341  2013-04-03 06:50:50  2013-04-03 12:12:37            69  \n",
+       "0              134  2013-04-03 06:48:47  2013-04-03 12:12:37            82  \n",
+       "1               24  2013-04-03 06:50:13  2013-04-03 14:58:35            87  \n",
+       "2                0  2013-04-03 09:55:05  2013-04-03 09:55:05             1  \n",
+       "3               67  2013-04-03 01:59:09  2013-04-03 22:05:39            25  \n",
+       "4               25  2013-04-03 06:48:01  2013-04-03 12:11:40            69  \n",
+       "5               24  2013-04-03 06:48:24  2013-04-03 15:17:39           112  \n",
        "6               18  2013-04-03 06:53:55  2013-04-03 15:11:07           104  \n",
-       "7               24  2013-04-03 07:19:02  2013-04-03 10:12:35            40  \n",
-       "8                0  2013-04-03 00:26:46  2013-04-03 23:06:00            29  \n",
-       "9               24  2013-04-03 06:48:24  2013-04-03 15:17:39           112  "
+       "7              341  2013-04-03 06:50:50  2013-04-03 12:12:37            69  \n",
+       "8                3  2013-04-03 06:48:21  2013-04-03 12:06:53            84  \n",
+       "9                0  2013-04-03 10:36:04  2013-04-03 10:36:04             1  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -445,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -458,24 +458,22 @@
      "text": [
       "Collecting pyspark\n",
       "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/87/21/f05c186f4ddb01d15d0ddc36ef4b7e3cedbeb6412274a41f26b55a650ee5/pyspark-2.4.4.tar.gz (215.7MB)\n",
-      "\u001b[K     |████████████████████████████████| 215.7MB 120kB/s  eta 0:00:01\n",
+      "\u001b[K     |████████████████████████████████| 215.7MB 50kB/s s eta 0:00:01\n",
       "\u001b[?25hCollecting py4j==0.10.7\n",
       "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e3/53/c737818eb9a7dc32a7cd4f1396e787bd94200c3997c72c1dbe028587bd76/py4j-0.10.7-py2.py3-none-any.whl (197kB)\n",
-      "\u001b[K     |████████████████████████████████| 204kB 42.6MB/s eta 0:00:01\n",
+      "\u001b[K     |████████████████████████████████| 204kB 54.4MB/s eta 0:00:01\n",
       "\u001b[?25hBuilding wheels for collected packages: pyspark\n",
       "  Building wheel for pyspark (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for pyspark: filename=pyspark-2.4.4-py2.py3-none-any.whl size=216130387 sha256=b8532cc448216d90842e896b6874ccd1d3c31623898e056052c6d5462dedbda6\n",
-      "  Stored in directory: /home/jupyter-winston/.cache/pip/wheels/ab/09/4d/0d184230058e654eb1b04467dbc1292f00eaa186544604b471\n",
+      "\u001b[?25h  Created wheel for pyspark: filename=pyspark-2.4.4-py2.py3-none-any.whl size=216130387 sha256=14abaa33edbf681f432ee00d234718731961da639e5eec86c4784667d43b4f5d\n",
+      "  Stored in directory: /home/winston/.cache/pip/wheels/ab/09/4d/0d184230058e654eb1b04467dbc1292f00eaa186544604b471\n",
       "Successfully built pyspark\n",
       "Installing collected packages: py4j, pyspark\n",
-      "\u001b[31mERROR: Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/opt/tljh/user/lib/python3.6/site-packages/py4j'\n",
-      "Consider using the `--user` option or check the permissions.\n",
-      "\u001b[0m\n"
+      "Successfully installed py4j-0.10.7 pyspark-2.4.4\n"
      ]
     }
    ],
    "source": [
-    "# installs Spark (2.4.4 Nov 2019)\n",
+    "# installs Spark (2.4.4 Jan 2020)\n",
     "!pip install pyspark"
    ]
   },
@@ -492,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -507,14 +505,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 50.3 ms, sys: 31.7 ms, total: 82 ms\n",
-      "Wall time: 8.63 s\n"
+      "CPU times: user 321 ms, sys: 208 ms, total: 529 ms\n",
+      "Wall time: 3.65 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "#I copied this cell's snippet from another Google Colab by Luca Canali here: https://colab.research.google.com/github/LucaCanali/sparkMeasure/blob/master/examples/SparkMeasure_Jupyter_Colab_Example.ipynb\n",
+    "# copied this cell's snippet from another Google Colab by Luca Canali here: https://colab.research.google.com/github/LucaCanali/sparkMeasure/blob/master/examples/SparkMeasure_Jupyter_Colab_Example.ipynb\n",
     "\n",
     "from pyspark.sql import SparkSession\n",
     "\n",
@@ -542,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -557,20 +555,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 73.3 ms, sys: 86.9 ms, total: 160 ms\n",
-      "Wall time: 2min 54s\n"
+      "CPU times: user 20.2 ms, sys: 11.3 ms, total: 31.5 ms\n",
+      "Wall time: 2min 46s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "# load CSV into Spark\n",
-    "netflow_df = spark.read.format('com.databricks.spark.csv').options(header='true', inferschema='true').load('nf-chunk2.csv')"
+    "netflow_df = spark.read.format('com.databricks.spark.csv').options(header='true', inferschema='true').load('data/nf-chunk2.csv')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -585,8 +583,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.68 ms, sys: 506 µs, total: 2.18 ms\n",
-      "Wall time: 171 ms\n"
+      "CPU times: user 1.72 ms, sys: 176 µs, total: 1.9 ms\n",
+      "Wall time: 157 ms\n"
      ]
     }
    ],
@@ -598,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -621,11 +619,16 @@
       "| 172.30.2.86|      172.0.0.1|          1|     540|      0|              2|2013-04-03 06:36:09|2013-04-03 06:36:09|           1|\n",
       "|172.30.1.246|      172.0.0.1|         29|    2610|   2610|              0|2013-04-03 00:26:46|2013-04-03 23:06:00|          29|\n",
       "| 172.30.1.51|239.255.255.250|         16|    3850|      0|             18|2013-04-03 06:35:22|2013-04-03 06:44:08|          16|\n",
+      "| 172.10.1.35|      172.0.0.1|          1|     270|      0|              0|2013-04-03 06:36:21|2013-04-03 06:36:21|           1|\n",
+      "| 172.20.1.91|239.255.255.250|         19|    3675|      0|              6|2013-04-03 06:36:50|2013-04-03 06:36:59|          19|\n",
+      "|172.20.1.249|239.255.255.250|          2|     700|      0|              6|2013-04-03 06:37:17|2013-04-03 06:37:23|           2|\n",
+      "|172.10.1.232|      172.0.0.1|         30|    3060|   3060|             48|2013-04-03 01:31:31|2013-04-03 22:53:36|          30|\n",
+      "|172.10.1.238|239.255.255.250|          2|     700|      0|              6|2013-04-03 06:36:44|2013-04-03 06:36:51|           2|\n",
       "+------------+---------------+-----------+--------+-------+---------------+-------------------+-------------------+------------+\n",
-      "only showing top 5 rows\n",
+      "only showing top 10 rows\n",
       "\n",
-      "CPU times: user 33 ms, sys: 28.3 ms, total: 61.2 ms\n",
-      "Wall time: 1min 11s\n"
+      "CPU times: user 4.39 ms, sys: 8.82 ms, total: 13.2 ms\n",
+      "Wall time: 1min 9s\n"
      ]
     }
    ],
@@ -681,7 +684,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/vs_pyspark_netflow.ipynb
+++ b/vs_pyspark_netflow.ipynb
@@ -9,10 +9,10 @@
    "source": [
     "# BlazingSQL vs. Apache Spark \n",
     "\n",
-    "Below we have one of our popular workloads running with [BlazingSQL](https://blazingsql.com/) + [RAPIDS AI](https://rapids.ai) and then running the entire ETL phase again, only this time with Apache Spark + PySpark.\n",
+    "Below we have one of our popular workloads running with [BlazingSQL](https://blazingsql.com/), and then with Apache Spark + PySpark.\n",
     "\n",
     "In this notebook, we will cover: \n",
-    "- How to read and query csv files with cuDF and BlazingSQL.\n",
+    "- How to read and query csv files with BlazingSQL.\n",
     "- How BlazingSQL compares against Apache Spark (analyzing over 20M records)."
    ]
   },
@@ -24,7 +24,7 @@
    },
    "source": [
     "## Import packages and create Blazing Context\n",
-    "You can think of the BlazingContext much like a Spark Context (i.e. where information such as FileSystems you have registered and Tables you have created will be stored). "
+    "You can think of the BlazingContext much like a Spark Context (i.e. information such as FileSystems you have registered and Tables you have created will be stored here). "
    ]
   },
   {
@@ -50,7 +50,6 @@
    ],
    "source": [
     "from blazingsql import BlazingContext\n",
-    "import cudf\n",
     "\n",
     "bc = BlazingContext()"
    ]
@@ -68,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -79,16 +78,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2019-11-15 09:07:34--  https://blazingsql-colab.s3.amazonaws.com/netflow_data/nf-chunk2.csv\n",
-      "Resolving blazingsql-colab.s3.amazonaws.com (blazingsql-colab.s3.amazonaws.com)... 52.216.186.195\n",
-      "Connecting to blazingsql-colab.s3.amazonaws.com (blazingsql-colab.s3.amazonaws.com)|52.216.186.195|:443... connected.\n",
+      "--2020-01-20 21:56:58--  https://blazingsql-colab.s3.amazonaws.com/netflow_data/nf-chunk2.csv\n",
+      "Resolving blazingsql-colab.s3.amazonaws.com (blazingsql-colab.s3.amazonaws.com)... 52.217.4.52\n",
+      "Connecting to blazingsql-colab.s3.amazonaws.com (blazingsql-colab.s3.amazonaws.com)|52.217.4.52|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 2725056295 (2.5G) [text/csv]\n",
       "Saving to: ‘data/nf-chunk2.csv’\n",
       "\n",
-      "nf-chunk2.csv       100%[===================>]   2.54G  35.5MB/s    in 69s     \n",
+      "nf-chunk2.csv       100%[===================>]   2.54G  46.2MB/s    in 48s     \n",
       "\n",
-      "2019-11-15 09:08:44 (37.4 MB/s) - ‘data/nf-chunk2.csv’ saved [2725056295/2725056295]\n",
+      "2020-01-20 21:57:47 (53.6 MB/s) - ‘data/nf-chunk2.csv’ saved [2725056295/2725056295]\n",
       "\n"
      ]
     }
@@ -105,15 +104,15 @@
     "id": "OTEaAsp2_zmf"
    },
    "source": [
-    "## BlazingSQL + cuDF \n",
-    "Data in hand, we can test the preformance of cuDF and BlazingSQL on this dataset. \n",
+    "## BlazingSQL \n",
+    "Data in hand, we can test the preformance of BlazingSQL on this dataset. \n",
     "\n",
     "To use pre-downloaded data, change the file path to `data/small-chunk2.csv`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -125,23 +124,29 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 4.01 s, sys: 1.09 s, total: 5.1 s\n",
-      "Wall time: 5.1 s\n"
-     ]
+     "data": {
+      "text/plain": [
+       "'/home/jupyter-winston/bsql-demos/data/nf-chunk2.csv'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "%%time\n",
-    "# Load CSVs into GPU DataFrames (GDF)\n",
-    "netflow_gdf = cudf.read_csv('data/nf-chunk2.csv')"
+    "import os\n",
+    "# determine current working directory \n",
+    "cwd = os.getcwd()\n",
+    "# complete path to data\n",
+    "path = cwd + '/data/nf-chunk2.csv'\n",
+    "# what's the path?\n",
+    "path"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -156,17 +161,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 22 ms, sys: 4.59 ms, total: 26.6 ms\n",
-      "Wall time: 47.7 ms\n"
+      "CPU times: user 7.4 ms, sys: 3.8 ms, total: 11.2 ms\n",
+      "Wall time: 10.9 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<pyblazing.apiv2.sql.Table at 0x7fa6a2efb9e8>"
+       "<pyblazing.apiv2.context.BlazingTable at 0x7f1ba8229198>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -174,12 +179,12 @@
    "source": [
     "%%time\n",
     "# Create BlazingSQL table from GDF - There is no copy in this process\n",
-    "bc.create_table('netflow', netflow_gdf)"
+    "bc.create_table('netflow', path, header=0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -194,8 +199,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 33 ms, sys: 307 µs, total: 33.3 ms\n",
-      "Wall time: 1.87 s\n"
+      "CPU times: user 4.3 s, sys: 2.51 s, total: 6.81 s\n",
+      "Wall time: 6.6 s\n"
      ]
     }
    ],
@@ -218,15 +223,15 @@
     "        GROUP BY\n",
     "            a.firstSeenSrcIp,\n",
     "            a.firstSeenDestIp\n",
-    "        '''\n",
+    "            '''\n",
     "\n",
     "# query the table (returns cuDF DataFrame)\n",
-    "result = bc.sql(query)"
+    "gdf = bc.sql(query)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -269,18 +274,6 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>172.30.2.60</td>\n",
-       "      <td>10.0.0.9</td>\n",
-       "      <td>82</td>\n",
-       "      <td>34839</td>\n",
-       "      <td>47716</td>\n",
-       "      <td>134</td>\n",
-       "      <td>2013-04-03 06:48:47</td>\n",
-       "      <td>2013-04-03 12:12:37</td>\n",
-       "      <td>82</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
        "      <td>172.10.1.162</td>\n",
        "      <td>10.0.0.11</td>\n",
        "      <td>87</td>\n",
@@ -292,19 +285,19 @@
        "      <td>87</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>172.10.1.234</td>\n",
-       "      <td>10.0.0.5</td>\n",
-       "      <td>104</td>\n",
-       "      <td>47287</td>\n",
-       "      <td>64750</td>\n",
-       "      <td>18</td>\n",
-       "      <td>2013-04-03 06:53:55</td>\n",
-       "      <td>2013-04-03 15:11:07</td>\n",
-       "      <td>104</td>\n",
+       "      <th>1</th>\n",
+       "      <td>172.30.2.60</td>\n",
+       "      <td>10.0.0.9</td>\n",
+       "      <td>82</td>\n",
+       "      <td>34839</td>\n",
+       "      <td>47716</td>\n",
+       "      <td>134</td>\n",
+       "      <td>2013-04-03 06:48:47</td>\n",
+       "      <td>2013-04-03 12:12:37</td>\n",
+       "      <td>82</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>2</th>\n",
        "      <td>172.30.1.56</td>\n",
        "      <td>172.0.0.1</td>\n",
        "      <td>25</td>\n",
@@ -316,16 +309,28 @@
        "      <td>25</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>172.30.1.85</td>\n",
+       "      <td>10.0.0.8</td>\n",
+       "      <td>84</td>\n",
+       "      <td>37828</td>\n",
+       "      <td>52864</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2013-04-03 06:48:21</td>\n",
+       "      <td>2013-04-03 12:06:53</td>\n",
+       "      <td>84</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>172.30.1.10</td>\n",
-       "      <td>10.0.0.12</td>\n",
-       "      <td>69</td>\n",
-       "      <td>31042</td>\n",
-       "      <td>43044</td>\n",
-       "      <td>25</td>\n",
-       "      <td>2013-04-03 06:48:01</td>\n",
-       "      <td>2013-04-03 12:11:40</td>\n",
-       "      <td>69</td>\n",
+       "      <td>10.1.0.76</td>\n",
+       "      <td>172.10.1.82</td>\n",
+       "      <td>1</td>\n",
+       "      <td>633</td>\n",
+       "      <td>392</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2013-04-03 09:55:05</td>\n",
+       "      <td>2013-04-03 09:55:05</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
@@ -341,30 +346,18 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>10.0.0.9</td>\n",
-       "      <td>172.30.1.124</td>\n",
-       "      <td>1</td>\n",
-       "      <td>632</td>\n",
-       "      <td>391</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2013-04-03 10:36:04</td>\n",
-       "      <td>2013-04-03 10:36:04</td>\n",
-       "      <td>1</td>\n",
+       "      <td>172.10.1.234</td>\n",
+       "      <td>10.0.0.5</td>\n",
+       "      <td>104</td>\n",
+       "      <td>47287</td>\n",
+       "      <td>64750</td>\n",
+       "      <td>18</td>\n",
+       "      <td>2013-04-03 06:53:55</td>\n",
+       "      <td>2013-04-03 15:11:07</td>\n",
+       "      <td>104</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>172.10.1.89</td>\n",
-       "      <td>10.0.0.5</td>\n",
-       "      <td>112</td>\n",
-       "      <td>51222</td>\n",
-       "      <td>70260</td>\n",
-       "      <td>24</td>\n",
-       "      <td>2013-04-03 06:48:24</td>\n",
-       "      <td>2013-04-03 15:17:39</td>\n",
-       "      <td>112</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
        "      <td>172.10.1.106</td>\n",
        "      <td>10.199.250.2</td>\n",
        "      <td>40</td>\n",
@@ -376,55 +369,67 @@
        "      <td>40</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>172.30.1.201</td>\n",
+       "      <td>172.0.0.1</td>\n",
+       "      <td>29</td>\n",
+       "      <td>2610</td>\n",
+       "      <td>2610</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2013-04-03 00:26:46</td>\n",
+       "      <td>2013-04-03 23:06:00</td>\n",
+       "      <td>29</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>172.20.1.58</td>\n",
-       "      <td>10.7.5.5</td>\n",
-       "      <td>49</td>\n",
-       "      <td>3041309</td>\n",
-       "      <td>116400561</td>\n",
-       "      <td>2091</td>\n",
-       "      <td>2013-04-03 10:12:27</td>\n",
-       "      <td>2013-04-03 11:20:09</td>\n",
-       "      <td>49</td>\n",
+       "      <td>172.10.1.89</td>\n",
+       "      <td>10.0.0.5</td>\n",
+       "      <td>112</td>\n",
+       "      <td>51222</td>\n",
+       "      <td>70260</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2013-04-03 06:48:24</td>\n",
+       "      <td>2013-04-03 15:17:39</td>\n",
+       "      <td>112</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "         source   destination  targetPorts  bytesOut    bytesIn  \\\n",
-       "0   172.30.2.60      10.0.0.9           82     34839      47716   \n",
-       "1  172.10.1.162     10.0.0.11           87     39628      53983   \n",
-       "2  172.10.1.234      10.0.0.5          104     47287      64750   \n",
-       "3   172.30.1.56     172.0.0.1           25      3330       3240   \n",
-       "4   172.30.1.10     10.0.0.12           69     31042      43044   \n",
-       "5  172.30.2.125      10.0.0.9           69     30701      41558   \n",
-       "6      10.0.0.9  172.30.1.124            1       632        391   \n",
-       "7   172.10.1.89      10.0.0.5          112     51222      70260   \n",
-       "8  172.10.1.106  10.199.250.2           40     66638    2863884   \n",
-       "9   172.20.1.58      10.7.5.5           49   3041309  116400561   \n",
+       "         source   destination  targetPorts  bytesOut  bytesIn  \\\n",
+       "0  172.10.1.162     10.0.0.11           87     39628    53983   \n",
+       "1   172.30.2.60      10.0.0.9           82     34839    47716   \n",
+       "2   172.30.1.56     172.0.0.1           25      3330     3240   \n",
+       "3   172.30.1.85      10.0.0.8           84     37828    52864   \n",
+       "4     10.1.0.76   172.10.1.82            1       633      392   \n",
+       "5  172.30.2.125      10.0.0.9           69     30701    41558   \n",
+       "6  172.10.1.234      10.0.0.5          104     47287    64750   \n",
+       "7  172.10.1.106  10.199.250.2           40     66638  2863884   \n",
+       "8  172.30.1.201     172.0.0.1           29      2610     2610   \n",
+       "9   172.10.1.89      10.0.0.5          112     51222    70260   \n",
        "\n",
        "   durationSeconds        firstFlowDate         lastFlowDate  attemptCount  \n",
-       "0              134  2013-04-03 06:48:47  2013-04-03 12:12:37            82  \n",
-       "1               24  2013-04-03 06:50:13  2013-04-03 14:58:35            87  \n",
-       "2               18  2013-04-03 06:53:55  2013-04-03 15:11:07           104  \n",
-       "3               67  2013-04-03 01:59:09  2013-04-03 22:05:39            25  \n",
-       "4               25  2013-04-03 06:48:01  2013-04-03 12:11:40            69  \n",
+       "0               24  2013-04-03 06:50:13  2013-04-03 14:58:35            87  \n",
+       "1              134  2013-04-03 06:48:47  2013-04-03 12:12:37            82  \n",
+       "2               67  2013-04-03 01:59:09  2013-04-03 22:05:39            25  \n",
+       "3                3  2013-04-03 06:48:21  2013-04-03 12:06:53            84  \n",
+       "4                0  2013-04-03 09:55:05  2013-04-03 09:55:05             1  \n",
        "5              341  2013-04-03 06:50:50  2013-04-03 12:12:37            69  \n",
-       "6                0  2013-04-03 10:36:04  2013-04-03 10:36:04             1  \n",
-       "7               24  2013-04-03 06:48:24  2013-04-03 15:17:39           112  \n",
-       "8               24  2013-04-03 07:19:02  2013-04-03 10:12:35            40  \n",
-       "9             2091  2013-04-03 10:12:27  2013-04-03 11:20:09            49  "
+       "6               18  2013-04-03 06:53:55  2013-04-03 15:11:07           104  \n",
+       "7               24  2013-04-03 07:19:02  2013-04-03 10:12:35            40  \n",
+       "8                0  2013-04-03 00:26:46  2013-04-03 23:06:00            29  \n",
+       "9               24  2013-04-03 06:48:24  2013-04-03 15:17:39           112  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# how's it look?\n",
-    "result_gdf.head(10)"
+    "gdf.head(10)"
    ]
   },
   {
@@ -440,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -453,17 +458,19 @@
      "text": [
       "Collecting pyspark\n",
       "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/87/21/f05c186f4ddb01d15d0ddc36ef4b7e3cedbeb6412274a41f26b55a650ee5/pyspark-2.4.4.tar.gz (215.7MB)\n",
-      "\u001b[K     |████████████████████████████████| 215.7MB 45kB/s \n",
+      "\u001b[K     |████████████████████████████████| 215.7MB 120kB/s  eta 0:00:01\n",
       "\u001b[?25hCollecting py4j==0.10.7\n",
       "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e3/53/c737818eb9a7dc32a7cd4f1396e787bd94200c3997c72c1dbe028587bd76/py4j-0.10.7-py2.py3-none-any.whl (197kB)\n",
-      "\u001b[K     |████████████████████████████████| 204kB 34.1MB/s \n",
+      "\u001b[K     |████████████████████████████████| 204kB 42.6MB/s eta 0:00:01\n",
       "\u001b[?25hBuilding wheels for collected packages: pyspark\n",
       "  Building wheel for pyspark (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for pyspark: filename=pyspark-2.4.4-py2.py3-none-any.whl size=216130387 sha256=96ddf4d6abfe8393746aa7873131979b2cfbecdc19853c0ee47fc671f672f7d5\n",
-      "  Stored in directory: /home/winston/.cache/pip/wheels/ab/09/4d/0d184230058e654eb1b04467dbc1292f00eaa186544604b471\n",
+      "\u001b[?25h  Created wheel for pyspark: filename=pyspark-2.4.4-py2.py3-none-any.whl size=216130387 sha256=b8532cc448216d90842e896b6874ccd1d3c31623898e056052c6d5462dedbda6\n",
+      "  Stored in directory: /home/jupyter-winston/.cache/pip/wheels/ab/09/4d/0d184230058e654eb1b04467dbc1292f00eaa186544604b471\n",
       "Successfully built pyspark\n",
       "Installing collected packages: py4j, pyspark\n",
-      "Successfully installed py4j-0.10.7 pyspark-2.4.4\n"
+      "\u001b[31mERROR: Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/opt/tljh/user/lib/python3.6/site-packages/py4j'\n",
+      "Consider using the `--user` option or check the permissions.\n",
+      "\u001b[0m\n"
      ]
     }
    ],
@@ -641,7 +648,7 @@
     "        GROUP BY\n",
     "            a.firstSeenSrcIp,\n",
     "            a.firstSeenDestIp\n",
-    "        '''\n",
+    "            '''\n",
     "\n",
     "# query with Spark\n",
     "edges_df = spark.sql(query)\n",
@@ -674,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/vs_pyspark_netflow.ipynb
+++ b/vs_pyspark_netflow.ipynb
@@ -220,11 +220,8 @@
     "            a.firstSeenDestIp\n",
     "        '''\n",
     "\n",
-    "# query the table\n",
-    "result = bc.sql(query).get()\n",
-    "\n",
-    "# extract cudf dataframe from results\n",
-    "result_gdf = result.columns"
+    "# query the table (returns cuDF DataFrame)\n",
+    "result = bc.sql(query)"
    ]
   },
   {
@@ -650,7 +647,7 @@
     "edges_df = spark.sql(query)\n",
     "\n",
     "# set/display results\n",
-    "edges_df.show(5)"
+    "edges_df.show(10)"
    ]
   }
  ],
@@ -681,5 +678,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
- updated to BlazingSQL v0.11
- timings on GCP single node T4
- https://colab.research.google.com/github/gumdropsteve/bsql-demos/blob/feature/vs_spark/vs_pyspark_netflow.ipynb